### PR TITLE
[Suggestion] use Twitter's REST API in startAccountFinder

### DIFF
--- a/js/blockchain.js
+++ b/js/blockchain.js
@@ -31,7 +31,7 @@ if (typeof XPCNativeWrapper === 'function') {
 browser.runtime.onMessage.addListener(function(request, sender, sendResponse) {
     if (typeof request.blockChainStart !== "undefined") {
         const blockChainableHost = (location.hostname === 'twitter.com');
-        const blockChainablePath = /^\/[0-9a-z_]+\/(?:following|followers)/.test(location.pathname);
+        const blockChainablePath = /^\/[0-9A-Za-z_]+\/(?:following|followers)/.test(location.pathname);
         const protected = $(".ProtectedTimeline").length > 0;
         const blockChainable = (blockChainableHost && blockChainablePath && !protected);
         if (blockChainable || request.blockChainStart == 'import') {

--- a/manifest.json
+++ b/manifest.json
@@ -19,7 +19,8 @@
     "webRequest",
     "webRequestBlocking",
     "*://*.twimg.com/",
-    "https://twitter.com/"
+    "https://twitter.com/*",
+    "https://api.twitter.com/*"
   ],
   "options_page": "options.html",
   "content_scripts": [


### PR DESCRIPTION
I have an another idea to improve twitter block chain: use Twitter's REST API(`api.twitter.com`) for getting followers.
There are several benefits in this idea.

- Faster blockchain: Can gather up to 200 followers per request.
- Can gather followers even from user who blocked me. (without export/import chain)
  - (Currently, We need to enter URL `twitter.com/(user-who-blocked-me)/followers` manually because there's no link to followers page).
- Thers's an another API to get rate-limit status: [`GET application/rate_limit_status`](https://developer.twitter.com/en/docs/developer-utilities/rate-limit-status/api-reference/get-application-rate_limit_status.html)

I modified blockchain.js to demonstrate this idea.
